### PR TITLE
Check BinBosco with TLC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+modules/other/BinBosco.toolbox/

--- a/modules/lib/Messaging.tla
+++ b/modules/lib/Messaging.tla
@@ -24,7 +24,7 @@ Init == mi = InitialState(Processes)
 LOCAL doSend[intf \in [Processes -> Seq(Message)], msgs \in SUBSET Message] ==
     IF msgs = {} THEN intf
     ELSE
-        LET m == CHOOSE m: m \in msgs
+        LET m == CHOOSE m \in msgs : TRUE
         IN doSend[[intf EXCEPT ![m[1]] = Append(@, m[2])], msgs \ {m}]
 
 \* Helper operator for Send()

--- a/modules/lib/Messaging.tla
+++ b/modules/lib/Messaging.tla
@@ -18,10 +18,12 @@ LOCAL InitialState(procs) == [ p \in procs |-> <<>> ]
 \* Initially no messages are undelivered
 Init == mi = InitialState(Processes)
 
-\* Function takes intf, the state of the message interface, and msgs, a set
-\* of << destination, payload >> pairs, and updates the state by adding
-\* the messages to the right queue of undelivered messages
-LOCAL doSend[intf \in [Processes -> Seq(Message)], msgs \in SUBSET Message] ==
+\* Function takes intf, the state of the messaging interface, and msgs, a
+\* set of << destination, message >> pairs, and updates the state by adding
+\* the message to the right (destination) queue of undelivered messages.
+LOCAL doSend[intf \in [Processes -> Seq(Message)],
+             msgs \in SUBSET 
+                 {<<proc, msg>> : proc \in Processes, msg \in Message}] ==
     IF msgs = {} THEN intf
     ELSE
         LET m == CHOOSE m \in msgs : TRUE

--- a/modules/other/BinBosco.tla
+++ b/modules/other/BinBosco.tla
@@ -62,6 +62,6 @@ Proc(p) ==
 
 Next == \E p \in Processes: Proc(p)
 
-Spec == Init /\ [][Next]_<<procs, mi>>
+Spec == Init /\ [][Next]_<<procs, mi, msgs>>
 
 =============================================================================

--- a/modules/other/BinBosco.tla
+++ b/modules/other/BinBosco.tla
@@ -8,8 +8,10 @@ ASSUME Cardinality(Data) \in { 1, 2 }
 
 VARIABLES procs, mi, msgs
 
+Rnd == Nat
+
 \* Type of vote
-Vote == [ round: Nat, estimate: Data ]
+Vote == [ round: Rnd, estimate: Data ]
 
 \* Type of message
 Message == [ src: Processes, vote: Vote ]

--- a/pluspy.py
+++ b/pluspy.py
@@ -3948,7 +3948,7 @@ class JSignalReturnWrapper(Wrapper):
         signalset.add(args[0])
         return args[1]
 
-wrappers["TLC"] = {
+wrappers["TLCExt"] = {
     "JWait": JWaitWrapper(),
     "JSignalReturn": JSignalReturnWrapper()
 }


### PR DESCRIPTION
Most notably are the two commits 752ad13 and 93200c0.  PlusPy execution should not be affected.

Due to conflicts with `Core.tla`, `Messaging.tla` is best copied to `modules/other/` for modelchecking with TLC.