### PR TITLE
Fix typo at tests

### DIFF
--- a/tests/regression/test7.scr
+++ b/tests/regression/test7.scr
@@ -1,4 +1,4 @@
-./pluspy -S0 -c100 QSort > test7.out 2>test7.out2
+./pluspy -S0 -c100 Qsort > test7.out 2>test7.out2
 if cmp -s test7.out regression/test7.exp
 then
     if cmp -s test7.out2 regression/test7.exp2


### PR DESCRIPTION
Use `Qsort` instead of `QSort` for test 7.

Test 7 was failing.

Thank you for this project =D