### PR TITLE
move match out of Rule class

### DIFF
--- a/pluspy.py
+++ b/pluspy.py
@@ -801,7 +801,7 @@ def match(name, s, rule, select=None):
         if len(select) == 1:
             return (name, a[select[0]], r)
         return (name, [ a[i] for i in select ], r)
-    if select != None:
+    if select is not None:
         return (t, a, r)
     return (name, (t, a), r)
 

--- a/pluspy.py
+++ b/pluspy.py
@@ -775,18 +775,25 @@ def parseError(a, r):
     return (False, a, r)
 
 
-
-# Handy routine for rules that simply call other rules
-# It parses s using the given rule and returns a node (name, (t, a), r)
-# where name is the type of the AST node and (t, a) the result of
-# parsing given the rule.
-#
-# If t is a "Concat" rule (sequence of other rules), then you can
-# select a subset using the select argument
-#
-# Otherwise, if select is not None, the result of the rule is
-# directly returned without adding a new AST node
 def match(name, s, rule, select=None):
+    """
+    Handy routine for rules that simply call other rules
+    It parses s using the given rule and returns a node (name, (t, a), r)
+    where name is the type of the AST node and (t, a) the result of
+    parsing given the rule and r is remaining tokens.
+
+    If t is a "Concat" rule (sequence of other rules), then you can
+    select a subset using the select argument.
+
+    Otherwise, if select is not None, the result of the rule is
+    directly returned without adding a new AST node.
+
+    :param name: the type of the AST node
+    :param s: list of tokens
+    :param rule: rule to parse s with
+    :param select: subset of rules to select
+    :return: AST node with selected rules
+    """
     (t, a, r) = rule.parse(s)
     if not t:
         return parseError([name] + a, r)


### PR DESCRIPTION

Making match just an ordinary function makes it easy to think about the code there. 

If it is a method of the `Rule` class then it could be overridden by the sub classes.
It takes thinking to see that no sub class is doing that. This change saves that thinking. 

Thanks! :pray: 